### PR TITLE
Refactor: ast should not know token

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,15 @@
 mod parser;
+use crate::parser::lexer::lexer::Lexer;
+use crate::parser::parser::Parser;
+use crate::parser::tokenizer::tokenizer::{Token, TokenType, Tokens};
 
 fn main() {
-    println!("Hello, world!");
+    let src = "let five = 5;
+    let ten = 10;"
+        .to_string();
+    let mut lexer = Lexer::new(&src);
+    let mut tokens = Tokens::new(lexer);
+    let mut parser = Parser::new(tokens);
+    parser.parse();
+    println!("{:?}", parser.program);
 }


### PR DESCRIPTION
## Motivation

AST should not know token type, because AST should be depend on it's token and lexer